### PR TITLE
アプリケーション全体に認証を設定し、未ログインの人は門の外に連れていく

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,8 @@
 class ApplicationController < ActionController::Base
   include SessionHelper
+  before_action :redirect_to_gate_unless_logged_in
+
+  def redirect_to_gate_unless_logged_in
+    redirect_to gate_path unless logged_in?
+  end
 end

--- a/app/controllers/gate_controller.rb
+++ b/app/controllers/gate_controller.rb
@@ -1,0 +1,6 @@
+class GateController < ApplicationController
+  skip_before_action :redirect_to_gate_unless_logged_in
+
+  def index
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class SessionsController < ApplicationController
+  skip_before_action :redirect_to_gate_unless_logged_in
+
   def create
     auth_hash = request.env["omniauth.auth"]
     pp auth_hash
@@ -23,7 +25,7 @@ class SessionsController < ApplicationController
 
       redirect_to root_path
     else
-      redirect_to root_path, alert: "Teacher TeacherのDiscordサーバに参加している人のみ利用できます"
+      redirect_to gate_path, alert: "当該Discordサーバへの参加が確認できませんでした"
     end
   end
 

--- a/app/views/gate/index.html.erb
+++ b/app/views/gate/index.html.erb
@@ -1,0 +1,6 @@
+<p>
+  このアプリケーションは、Teacher TeacherのDiscordサーバに参加している人だけが利用できます。
+</p>
+<%= form_tag("/auth/discord", method: "post", data: { turbo: false }) do %>
+  <button type="submit">Discordでログイン</button>
+<% end %>

--- a/app/views/layouts/_login.html.erb
+++ b/app/views/layouts/_login.html.erb
@@ -6,8 +6,4 @@
   <div>
     <%= link_to "ログアウト", session_path, data: { turbo_method: :delete } %>
   </div>
-<% else %>
-  <%= form_tag("/auth/discord", method: "post", data: { turbo: false }) do %>
-    <button type="submit">Discordでログイン</button>
-  <% end %>
 <% end %>

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -1,4 +1,3 @@
-<% if logged_in? %>
 <h2>
   Members
 </h2>
@@ -10,4 +9,3 @@
   </li>
   <% end %>
 </ul>
-<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,6 @@ Rails.application.routes.draw do
 
   get    "/auth/discord/callback", to: "sessions#create"
   delete "/session",               to: "sessions#destroy", as: "session"
+  get    "/gate",                  to: "gate#index"
   root   "root#index"
 end


### PR DESCRIPTION
個別のコントローラで「忘れずに認証する！」とがんばるとどこかで事故を起こすと思うので、基底コントローラに認証チェックを入れて、以降は「ふつうに実装すれば、ふつうに認証される」という状態にします :muscle:
