### PR TITLE
自分のスケジュールとみんなのスケジュールは、ページをわけて表示する

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -23,7 +23,7 @@ body {
 .container {
   max-width: 560px;
   margin: 0 auto;
-  padding: 0 20px;
+  padding: 0 20px 20px;
   background-color: #fff;
 }
 
@@ -66,7 +66,7 @@ body {
 .schedules {
   position: relative;
   width: 100%;
-  padding-bottom: 80px;
+  padding-bottom: 60px;
 
   form {
     input[type="submit"] {
@@ -140,6 +140,11 @@ body {
       display: inline-block;
       line-height: 32px;
       vertical-align: top;
+    }
+
+    .member-name {
+      width: 120px;
+      margin-left: 4px;
     }
   }
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -143,7 +143,7 @@ body {
     }
 
     .member-name {
-      width: 120px;
+      width: 130px;
       margin-left: 4px;
     }
   }

--- a/app/controllers/me_controller.rb
+++ b/app/controllers/me_controller.rb
@@ -1,0 +1,5 @@
+class MeController < ApplicationController
+  def index
+    @dates = Date.today.upto(Date.today + 14.days).reject { Oyasumi.oyasumi?(_1) }
+  end
+end

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -17,6 +17,6 @@ class SchedulesController < ApplicationController
       schedule.update(schedule_param)
     end
 
-    redirect_to schedules_path
+    redirect_to me_path
   end
 end

--- a/app/views/me/index.html.erb
+++ b/app/views/me/index.html.erb
@@ -1,0 +1,26 @@
+<div class="schedules">
+<h2>
+  わたしのスケジュール
+</h2>
+<%= form_with(url: schedules_path, method: :post, data: { turbo: false }) do |f| %>
+  <% @dates.each do |date| %>
+    <div class="schedule-form">
+      <div class="schedule-date-and-status">
+        <% schedule = current_member.schedules.find_or_initialize_by(date: date) %>
+        <% status_selected = schedule.new_record? ? nil : schedule.status_before_type_cast %>
+        <span class="date"><%= "%d月%d日" % [date.month, date.day] %> (<%= %w[日 月 火 水 木 金 土][date.wday] %>)</span>
+        <%= hidden_field_tag("schedules[][date]", date) %>
+        <%= hidden_field_tag("schedules[][status]", status_selected, id: "#{date}-status") %>
+        <span class="status-selection">
+          <%= image_tag("status-ok.png", size: 32, data: { status: 0, date: date.to_s }, class: "clickable #{'selected' if status_selected == 0}") %>
+          <%= image_tag("status-ng.png", size: 32, data: { status: 2, date: date.to_s }, class: "clickable #{'selected' if status_selected == 2}") %>
+        </span>
+      </div>
+      <div class="schedule-memo">
+        <%= text_field_tag("schedules[][memo]", schedule.memo, placeholder: "メモ") %>
+      </div>
+    </div>
+  <% end %>
+  <%= f.submit("スケジュールを保存する") %>
+<% end %>
+</div>

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -3,7 +3,10 @@
 </h2>
 <ul>
   <li>
-    <%= link_to("スケジュール", schedules_path) %>
+    <%= link_to("マイページ", me_path) %>
+  </li>
+  <li>
+    <%= link_to("みんなのスケジュール", schedules_path) %>
   </li>
 </ul>
 <h2>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -1,30 +1,3 @@
-<div class="schedules">
-
-<h2>
-  自分のスケジュール
-</h2>
-<%= form_with(url: schedules_path, method: :post, data: { turbo: false }) do |f| %>
-  <% @dates.each do |date| %>
-    <div class="schedule-form">
-      <div class="schedule-date-and-status">
-        <% schedule = current_member.schedules.find_or_initialize_by(date: date) %>
-        <% status_selected = schedule.new_record? ? nil : schedule.status_before_type_cast %>
-        <span class="date"><%= "%d月%d日" % [date.month, date.day] %> (<%= %w[日 月 火 水 木 金 土][date.wday] %>)</span>
-        <%= hidden_field_tag("schedules[][date]", date) %>
-        <%= hidden_field_tag("schedules[][status]", status_selected, id: "#{date}-status") %>
-        <span class="status-selection">
-          <%= image_tag("status-ok.png", size: 32, data: { status: 0, date: date.to_s }, class: "clickable #{'selected' if status_selected == 0}") %>
-          <%= image_tag("status-ng.png", size: 32, data: { status: 2, date: date.to_s }, class: "clickable #{'selected' if status_selected == 2}") %>
-        </span>
-      </div>
-      <div class="schedule-memo">
-        <%= text_field_tag("schedules[][memo]", schedule.memo, placeholder: "メモ") %>
-      </div>
-    </div>
-  <% end %>
-  <%= f.submit("スケジュールを保存する") %>
-<% end %>
-
 <h2>
   みんなのスケジュール
 </h2>
@@ -36,6 +9,7 @@
   <% schedules.each do |schedule| %>
     <li class="schedule-<%= schedule.status %>">
       <%= image_tag(schedule.member.icon_url, size: 32, class: "member-icon") %>
+      <span class="member-name"><%= schedule.member.name %></span>
       <span><%= schedule.status_in_symbol %></span>
       <span><%= schedule.memo %></span>
     </li>
@@ -47,5 +21,3 @@
   </p>
   <% end %>
 <% end %>
-
-</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   get    "/gate",                  to: "gate#index"
   get    "/auth/discord/callback", to: "sessions#create"
   delete "/session",               to: "sessions#destroy",  as: "session"
+  get    "/me",                    to: "me#index"
   get    "/schedules",             to: "schedules#index"
   post   "/schedules",             to: "schedules#create"
   root   "root#index"


### PR DESCRIPTION
これまで同じページに詰め込んでいたけれど

- 自分のスケジュールを入力したい人
- みんなのスケジュールを把握したい人

は別で、ユースケースがそれぞれに存在するから、ページをわけることにします。これで今後の改修をやりやすくなるはず :muscle:
