### PR TITLE
ボランティアの人たち向けのDiscord通知の内容を洗練させる

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :development, :test do
 end
 
 group :development do
+  gem "dotenv"
   gem "web-console"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,7 @@ GEM
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    dotenv (3.1.2)
     drb (2.2.1)
     erubi (1.13.0)
     faraday (2.10.0)
@@ -304,7 +305,7 @@ GEM
 PLATFORMS
   aarch64-linux
   arm-linux
-  arm64-darwin
+  arm64-darwin-23
   x86-linux
   x86_64-darwin
   x86_64-linux
@@ -313,6 +314,7 @@ DEPENDENCIES
   bootsnap
   capybara
   debug
+  dotenv
   holiday_jp
   importmap-rails
   jbuilder

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -9,7 +9,7 @@ class Notification
     with_assignments, without_assignments = schedules.partition(&:assignment)
 
     fields = [{
-      name: "お願いするみなさんです！当日9:00からよろしくです",
+      name: "お願いするみなさんです！",
       value: with_assignments.map { "<@!#{_1.member.discord_uid}>" }.join(" "),
     }]
     fields.push({
@@ -19,10 +19,17 @@ class Notification
 
     embeds = [{
       title: ":date: %d/%d(%s)のボランティアの担当をお知らせ :date:" % [date.month, date.day, %w[日 月 火 水 木 金 土][date.wday]],
-      url: "https://bit.ly/tt-manabiya",
+      description: "9:00になりましたら会場にお入りください！\n :school: [MetaLife会場](%s) ┃ :memo: [案内ドキュメント](%s)" % [
+        ENV["SCHOOL_URL"], ENV["SCHOOL_DOCUMENT_URL"]
+      ],
       fields: fields,
     }]
 
-    pp @bot.send_message(channel_or_thread_id: @thread_id, embeds:)
+    content = schedules.map { "<@!#{_1.member.discord_uid}>" }.join(" ")
+    allowed_mentions = {
+      parse: ["users"]
+    }
+
+    pp @bot.send_message(channel_or_thread_id: @thread_id, content:, embeds:, allowed_mentions:)
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,8 @@ require "rails/all"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+require "dotenv/load"
+
 module Manabiya
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.

--- a/lib/discord.rb
+++ b/lib/discord.rb
@@ -33,9 +33,9 @@ module Discord
       )
     end
 
-    def send_message(channel_or_thread_id:, content: nil, embeds: nil)
+    def send_message(channel_or_thread_id:, content: nil, embeds: nil, allowed_mentions: nil)
       response = @connection.post("#{BASE_PATH}/channels/#{channel_or_thread_id}/messages") do |req|
-        req.body = { content: content, embeds: embeds }.to_json
+        req.body = { content:, embeds:, allowed_mentions: }.to_json
       end
       JSON.parse(response.body)
     end


### PR DESCRIPTION
- メンションで通知を送るようにしたい
- 会場の URL をメッセージ内に含めたい
- 案内ドキュメントの URL も含めちゃお
