### PR TITLE
Dotenvが定義されているときだけloadを行う

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -6,7 +6,7 @@ require "rails/all"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-require "dotenv/load"
+require "dotenv/load" if defined?(Dotenv)
 
 module Manabiya
   class Application < Rails::Application


### PR DESCRIPTION
- 現状、Dotenvはdevelopment環境にしか導入していない
- その状態でproductionにデプロイしたらアプリケーションの起動に失敗した
- 定義されているときだけloadすることで大丈夫になるはず
