### PR TITLE
居住地や出身地を表現するRegionモデルを導入する

### DIFF
--- a/app/controllers/member_regions_controller.rb
+++ b/app/controllers/member_regions_controller.rb
@@ -1,0 +1,15 @@
+class MemberRegionsController < ApplicationController
+  def create
+    mr = current_member.member_regions.new(region_id: params[:member_region][:region_id])
+    mr.save
+
+    redirect_to(regions_path, notice: "居住地を登録しました")
+  end
+
+  def destroy
+    mr = current_member.member_regions.find(params[:member_region_id])
+    mr.destroy
+
+    redirect_to(regions_path, notice: "居住地の登録を解除しました")
+  end
+end

--- a/app/controllers/regions_controller.rb
+++ b/app/controllers/regions_controller.rb
@@ -1,0 +1,6 @@
+class RegionsController < ApplicationController
+  def index
+    @regions = Region.order(:id).includes(:members)
+    @my_regions = current_member.member_regions
+  end
+end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,6 +1,8 @@
 class Member < ApplicationRecord
   has_many :schedules, dependent: :destroy
   has_many :assignments, through: :schedules
+  has_many :member_regions, dependent: :destroy
+  has_many :regions, through: :member_regions
 
   validates :discord_uid, presence: true, uniqueness: true
   validates :name, presence: true, length: { maximum: 32 }

--- a/app/models/member_region.rb
+++ b/app/models/member_region.rb
@@ -1,0 +1,15 @@
+class MemberRegion < ApplicationRecord
+  belongs_to :member
+  belongs_to :region
+
+  validates :member_id, presence: true
+  validates :region_id, presence: true
+  validates :category, presence: true
+
+  enum category: {
+    "現在の居住地": 0,
+    "かつての居住地": 1,
+    "出身地": 2,
+    "その他": 3,
+  }
+end

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -1,0 +1,4 @@
+class Region < ApplicationRecord
+  validates :code, presence: true, uniqueness: true
+  validates :name, presence: true
+end

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -1,4 +1,7 @@
 class Region < ApplicationRecord
+  has_many :member_regions, dependent: :destroy
+  has_many :members, through: :member_regions
+
   validates :code, presence: true, uniqueness: true
   validates :name, presence: true
 end

--- a/app/views/regions/index.html.erb
+++ b/app/views/regions/index.html.erb
@@ -8,11 +8,15 @@
     <%= f.submit("登録する", class: "bg-rose-500 text-white px-4 py-2 rounded-md hover:cursor-pointer") %>
   <% end %>
 
-  <ul class="mt-4">
+  <ul class="mt-8">
     <% @my_regions.each do |member_region| %>
       <li>
-        <%= member_region.region.name %>
-        <%= link_to("登録を解除する", member_region_path(member_region), data: { turbo_method: :delete }) %>
+        <span class="px-4 py-4 bg-gray-200 rounded-md">
+          <%= member_region.category %>
+          :
+          <%= member_region.region.name %>
+        </span>
+        <%= link_to("登録解除", member_region_path(member_region), data: { turbo_method: :delete }, class: "ml-2") %>
       </li>
     <% end %>
   </ul>

--- a/app/views/regions/index.html.erb
+++ b/app/views/regions/index.html.erb
@@ -1,0 +1,39 @@
+<section class="mb-10">
+  <h2 class="text-2xl font-bold mb-4">
+    わたしの居住地
+  </h2>
+
+  <%= form_for(MemberRegion.new) do |f| %>
+    <%= f.select(:region_id, Region.all.map { [_1.name, _1.id] }) %>
+    <%= f.submit("登録する", class: "bg-rose-500 text-white px-4 py-2 rounded-md hover:cursor-pointer") %>
+  <% end %>
+
+  <ul class="mt-4">
+    <% @my_regions.each do |member_region| %>
+      <li>
+        <%= member_region.region.name %>
+        <%= link_to("登録を解除する", member_region_path(member_region), data: { turbo_method: :delete }) %>
+      </li>
+    <% end %>
+  </ul>
+</section>
+
+<section>
+  <h2 class="text-2xl font-bold mb-4">
+    みんなの居住地
+  </h2>
+
+  <% @regions.each do |region| %>
+    <h3 class="text-xl mb-2">
+      <%= region.name %>
+    </h3>
+    <ul class="flex flex-wrap gap-4 mb-5">
+      <% region.members.each do |member| %>
+        <li class="flex items-center space-x-2">
+          <%= image_tag(member.icon_url, size: "32x32", class: "rounded-full") %>
+          <span class="font-bold"><%= member.name %></span>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+</section>

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -2,7 +2,7 @@
   メニュー
 </h2>
 <ul class="mb-6">
-  <% [["わたしのスケジュール", me_path], ["みんなのスケジュール", schedules_path]].each do |text, path| %>
+  <% [["わたしのスケジュール", me_path], ["みんなのスケジュール", schedules_path], ["みんなの居住地", regions_path]].each do |text, path| %>
   <li class="mb-2">
     <%= link_to(text, path, class: "inline-block w-full bg-white p-4 rounded-md shadow-md") %>
   </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,5 +15,10 @@ Rails.application.routes.draw do
   delete "/schedules/:schedule_id/assignment", to: "assignments#destroy"
   post   "/schedules/:date/notification",      to: "notifications#create",
                                                as: "notification"
+  get    "/regions",                           to: "regions#index"
+  post   "/member_regions",                    to: "member_regions#create"
+  delete "/member_regions/:member_region_id",  to: "member_regions#destroy",
+                                               as: "member_region"
+
   root   "root#index"
 end

--- a/db/migrate/20240731132334_create_regions.rb
+++ b/db/migrate/20240731132334_create_regions.rb
@@ -1,0 +1,13 @@
+class CreateRegions < ActiveRecord::Migration[7.1]
+  def change
+    create_table :regions do |t|
+      t.string :code, null: false
+      t.string :name, null: false
+
+      t.timestamps
+    end
+
+    add_index :regions, :code, unique: true
+    add_index :regions, :name
+  end
+end

--- a/db/migrate/20240731135819_create_member_regions.rb
+++ b/db/migrate/20240731135819_create_member_regions.rb
@@ -1,0 +1,11 @@
+class CreateMemberRegions < ActiveRecord::Migration[7.1]
+  def change
+    create_table :member_regions do |t|
+      t.references :member, null: false, foreign_key: true
+      t.references :region, null: false, foreign_key: true
+      t.integer :category, null: false, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_15_081644) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_31_132334) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -28,6 +28,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_15_081644) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["discord_uid"], name: "index_members_on_discord_uid", unique: true
+  end
+
+  create_table "regions", force: :cascade do |t|
+    t.string "code", null: false
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["code"], name: "index_regions_on_code", unique: true
+    t.index ["name"], name: "index_regions_on_name"
   end
 
   create_table "schedules", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_31_132334) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_31_135819) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_31_132334) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["schedule_id"], name: "index_assignments_on_schedule_id", unique: true
+  end
+
+  create_table "member_regions", force: :cascade do |t|
+    t.bigint "member_id", null: false
+    t.bigint "region_id", null: false
+    t.integer "category", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["member_id"], name: "index_member_regions_on_member_id"
+    t.index ["region_id"], name: "index_member_regions_on_region_id"
   end
 
   create_table "members", force: :cascade do |t|
@@ -52,5 +62,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_31_132334) do
   end
 
   add_foreign_key "assignments", "schedules"
+  add_foreign_key "member_regions", "members"
+  add_foreign_key "member_regions", "regions"
   add_foreign_key "schedules", "members"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,55 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+regions = [
+  { code: "JP-01", name: "北海道" },
+  { code: "JP-02", name: "青森県" },
+  { code: "JP-03", name: "岩手県" },
+  { code: "JP-04", name: "宮城県" },
+  { code: "JP-05", name: "秋田県" },
+  { code: "JP-06", name: "山形県" },
+  { code: "JP-07", name: "福島県" },
+  { code: "JP-08", name: "茨城県" },
+  { code: "JP-09", name: "栃木県" },
+  { code: "JP-10", name: "群馬県" },
+  { code: "JP-11", name: "埼玉県" },
+  { code: "JP-12", name: "千葉県" },
+  { code: "JP-13", name: "東京都" },
+  { code: "JP-14", name: "神奈川県" },
+  { code: "JP-15", name: "新潟県" },
+  { code: "JP-16", name: "富山県" },
+  { code: "JP-17", name: "石川県" },
+  { code: "JP-18", name: "福井県" },
+  { code: "JP-19", name: "山梨県" },
+  { code: "JP-20", name: "長野県" },
+  { code: "JP-21", name: "岐阜県" },
+  { code: "JP-22", name: "静岡県" },
+  { code: "JP-23", name: "愛知県" },
+  { code: "JP-24", name: "三重県" },
+  { code: "JP-25", name: "滋賀県" },
+  { code: "JP-26", name: "京都府" },
+  { code: "JP-27", name: "大阪府" },
+  { code: "JP-28", name: "兵庫県" },
+  { code: "JP-29", name: "奈良県" },
+  { code: "JP-30", name: "和歌山県" },
+  { code: "JP-31", name: "鳥取県" },
+  { code: "JP-32", name: "島根県" },
+  { code: "JP-33", name: "岡山県" },
+  { code: "JP-34", name: "広島県" },
+  { code: "JP-35", name: "山口県" },
+  { code: "JP-36", name: "徳島県" },
+  { code: "JP-37", name: "香川県" },
+  { code: "JP-38", name: "愛媛県" },
+  { code: "JP-39", name: "高知県" },
+  { code: "JP-40", name: "福岡県" },
+  { code: "JP-41", name: "佐賀県" },
+  { code: "JP-42", name: "長崎県" },
+  { code: "JP-43", name: "熊本県" },
+  { code: "JP-44", name: "大分県" },
+  { code: "JP-45", name: "宮崎県" },
+  { code: "JP-46", name: "鹿児島県" },
+  { code: "JP-47", name: "沖縄県" },
+]
+
+regions.each do |r|
+  region = Region.find_or_initialize_by(code: r[:code])
+  region.name = r[:name]
+  region.save!
+end


### PR DESCRIPTION
- Regionモデルを実装する
- まずは「現在の居住地」を登録するインターフェイスまでつくる
  - 「出身地」「以前に住んでいた地」の入力は、追って対応したい
- 日本の47都道府県のデータを用意する
  - 国外の地域のデータは、このあとの作業で対応したい
