### PR TITLE
プロフィールアイコン未設定だとログインに失敗するよ、の注意書きを置く

### DIFF
--- a/app/views/gate/index.html.erb
+++ b/app/views/gate/index.html.erb
@@ -1,6 +1,9 @@
 <p class="mb-4">
   このアプリケーションは、Teacher TeacherのDiscordサーバに参加している人だけが利用できます。
 </p>
-<%= form_tag("/auth/discord", method: "post", data: { turbo: false }) do %>
+<%= form_tag("/auth/discord", method: "post", data: { turbo: false }, class: "mb-4") do %>
   <button type="submit" class="w-full bg-rose-500 hover:bg-rose-400 text-white font-bold py-2 px-4 rounded">Discordでログイン</button>
 <% end %>
+<p>
+  Discordのプロフィールアイコンを設定していないとログインできない場合があります。ログインに失敗してしまったら、プロフィールアイコンを設定してあらためてお試しください。
+</p>


### PR DESCRIPTION
### 背景

Discordのプロフィールアイコンが未設定の場合、OAuth2の認証時にimageがnilなデータになるってことがわかった。

https://github.com/teacherteacher-jp/manabiya/blob/2680679e7a0134110d47d722daeab6da6151cb5a/app/controllers/sessions_controller.rb#L16

デフォルト画像のURLでもなく、nilが返ってくる。そうするとMemberモデルのvalidationに引っかかって保存に失敗し、ログインもできない。という事象。

### 対応内容

アイコン未設定でもログインできるようにする、が筋な気はしている。けれど、コミュニティにおいては、プロフィールアイコンは設定してもらった方がなにかといい。コミュニケーションがリッチになる。また、Manabiyaにおいてもアイコンを並べるようなビューがあり、そのときに誰が誰だかわかった方がうれしい。

というわけで「プロフィールアイコンを設定する」を推奨するメッセージを表示することとする！
