### PR TITLE
DiscordにURLを通知するとき、プレビューしてほしくない

### DIFF
--- a/app/controllers/webhooks/metalife_controller.rb
+++ b/app/controllers/webhooks/metalife_controller.rb
@@ -1,7 +1,7 @@
 class Webhooks::MetalifeController < WebhooksController
   def create
-    content = "MetaLife: #{params[:text]}"
-    content += "\n%s" % [ENV["COMMUNITY_CENTER_URL"]] if content.include?("入室しました")
+    content = params[:text]
+    content += "\n<%s>" % [ENV["COMMUNITY_CENTER_URL"]] if content.include?("入室しました")
 
     token = Rails.application.credentials.dig(:discord_app, :bot_token)
     thread_id = Rails.application.credentials.dig(:discord, :community_center_thread_id)


### PR DESCRIPTION
URLを `<>` で囲ってやると、リンクプレビューが表示されなくなるみたい :bulb:
