### PR TITLE
イベント機能の各種ページのスタイルを整えていく

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,4 +2,8 @@ module ApplicationHelper
   def mdw(date)
     "%d/%d(%s)" % [date.to_date.month, date.to_date.day, %w[日 月 火 水 木 金 土][date.wday]]
   end
+
+  def mdwhm(time)
+    "%s %s" % [mdw(time), time.strftime("%H:%M")]
+  end
 end

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -1,46 +1,46 @@
-<%= form_with(model: event, local: true, data: { turbo: false }, class: "bg-white rounded-lg shadow-lg p-8") do |f| %>
+<%= form_with(model: event, local: true, data: { turbo: false }) do |f| %>
   <div class="mb-6">
-    <%= f.label :title, 'タイトル', class: "block text-gray-700 text-sm font-bold mb-2" %>
-    <%= f.text_field :title, class: "shadow appearance-none border #{'border-red-500' if event.errors[:title].any?} rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" %>
+    <%= f.label(:title, "タイトル", class: "block text-gray-700 font-bold mb-2") %>
+    <%= f.text_field(:title, placeholder: "イベントのタイトル (最大50文字)", class: "shadow appearance-none border #{'border-red-500' if event.errors[:title].any?} rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline") %>
     <% if event.errors[:title].any? %>
-      <p class="text-red-500 text-xs italic mt-1"><%= event.errors[:title].join(', ') %></p>
+      <p class="text-red-500 text-xs italic mt-1"><%= event.errors[:title].join(", ") %></p>
     <% end %>
   </div>
 
   <div class="mb-6">
-    <%= f.label :description, '説明', class: "block text-gray-700 text-sm font-bold mb-2" %>
-    <%= f.text_area :description, rows: 4, class: "shadow appearance-none border #{'border-red-500' if event.errors[:description].any?} rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" %>
+    <%= f.label(:description, "説明", class: "block text-gray-700 font-bold mb-2") %>
+    <%= f.text_area(:description, placeholder: "イベントの概要 (最大200文字)", rows: 4, class: "shadow appearance-none border #{'border-red-500' if event.errors[:description].any?} rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline") %>
     <% if event.errors[:description].any? %>
-      <p class="text-red-500 text-xs italic mt-1"><%= event.errors[:description].join(', ') %></p>
+      <p class="text-red-500 text-xs italic mt-1"><%= event.errors[:description].join(", ") %></p>
     <% end %>
   </div>
 
   <div class="mb-6">
-    <%= f.label :start_at, '開始日時', class: "block text-gray-700 text-sm font-bold mb-2" %>
-    <%= f.datetime_local_field :start_at, class: "shadow appearance-none border #{'border-red-500' if event.errors[:start_at].any?} rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" %>
+    <%= f.label(:start_at, "開始日時", class: "block text-gray-700 font-bold mb-2") %>
+    <%= f.datetime_local_field(:start_at, class: "shadow appearance-none border #{'border-red-500' if event.errors[:start_at].any?} rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline") %>
     <% if event.errors[:start_at].any? %>
-      <p class="text-red-500 text-xs italic mt-1"><%= event.errors[:start_at].join(', ') %></p>
+      <p class="text-red-500 text-xs italic mt-1"><%= event.errors[:start_at].join(", ") %></p>
     <% end %>
   </div>
 
   <div class="mb-6">
-    <%= f.label :venue, '会場', class: "block text-gray-700 text-sm font-bold mb-2" %>
-    <%= f.text_field :venue, class: "shadow appearance-none border #{'border-red-500' if event.errors[:venue].any?} rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" %>
+    <%= f.label(:venue, "会場", class: "block text-gray-700 font-bold mb-2") %>
+    <%= f.text_field(:venue, placeholder: "談話室 or 公民館 or ...", class: "shadow appearance-none border #{'border-red-500' if event.errors[:venue].any?} rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline") %>
     <% if event.errors[:venue].any? %>
-      <p class="text-red-500 text-xs italic mt-1"><%= event.errors[:venue].join(', ') %></p>
+      <p class="text-red-500 text-xs italic mt-1"><%= event.errors[:venue].join(", ") %></p>
     <% end %>
   </div>
 
   <div class="mb-6">
-    <%= f.label :source_link, '詳細リンク', class: "block text-gray-700 text-sm font-bold mb-2" %>
-    <%= f.text_field :source_link, class: "shadow appearance-none border #{'border-red-500' if event.errors[:source_link].any?} rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" %>
+    <%= f.label(:source_link, "詳細リンク", class: "block text-gray-700 font-bold mb-2") %>
+    <%= f.text_field(:source_link, placeholder: "https://discord.com/...", class: "shadow appearance-none border #{'border-red-500' if event.errors[:source_link].any?} rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline") %>
     <% if event.errors[:source_link].any? %>
-      <p class="text-red-500 text-xs italic mt-1"><%= event.errors[:source_link].join(', ') %></p>
+      <p class="text-red-500 text-xs italic mt-1"><%= event.errors[:source_link].join(", ") %></p>
     <% end %>
   </div>
 
   <div class="flex items-center justify-between">
-    <%= f.submit submit_text, class: "bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" %>
-    <%= link_to '戻る', events_path, class: "text-gray-600 hover:text-gray-800" %>
+    <%= link_to("戻る", events_path, class: "text-gray-600 hover:text-gray-800") %>
+    <%= f.submit(submit_text, class: "pointer bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline") %>
   </div>
 <% end %>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,4 +1,7 @@
-<div class="container mx-auto px-4 py-8">
-  <h1 class="font-bold text-4xl mb-6">イベントの編集</h1>
-  <%= render 'form', event: @event, submit_text: '更新する' %>
-</div>
+<% content_for(:title) { "イベント編集" } %>
+
+<h2 class="text-2xl font-bold mb-4">
+  イベント編集
+</h2>
+
+<%= render("form", event: @event, submit_text: "更新する") %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -14,7 +14,7 @@
       <div class="bg-white rounded-lg shadow p-6">
         <h2 class="font-bold text-xl mb-2"><%= event.title %></h2>
         <div class="text-sm text-gray-500">
-          <p>開始: <%= event.start_at.strftime("%Y年%m月%d日 %H:%M") %></p>
+          <p>開始: <%= mdwhm(event.start_at) %></p>
           <p>会場: <%= event.venue %></p>
         </div>
       </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -8,7 +8,7 @@
   <%= link_to("イベントを登録する", new_event_path, class: "fixed bottom-4 right-4 bg-rose-500 text-lg font-bold text-white px-6 py-4 rounded-md cursor-pointer") %>
 </p>
 
-<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-24">
   <% @events.each do |event| %>
     <%= link_to event_path(event), class: "block hover:shadow-lg transition duration-200" do %>
       <div class="bg-white rounded-lg shadow p-6">

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,19 +1,23 @@
-<div class="container mx-auto px-4 py-8">
-  <h1 class="font-bold text-4xl mb-6">イベント一覧</h1>
+<% content_for(:title) { "イベント一覧" } %>
 
-  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-    <% @events.each do |event| %>
-      <%= link_to event_path(event), class: 'block hover:shadow-lg transition duration-200' do %>
-        <div class="bg-white rounded-lg shadow p-6">
-          <h2 class="font-bold text-xl mb-2"><%= event.title %></h2>
-          <div class="text-sm text-gray-500">
-            <p>開始: <%= event.start_at.strftime('%Y年%m月%d日 %H:%M') %></p>
-            <p>会場: <%= event.venue %></p>
-          </div>
+<h2 class="text-2xl font-bold mb-4">
+  イベント一覧
+</h2>
+
+<p>
+  <%= link_to("イベントを登録する", new_event_path, class: "fixed bottom-4 right-4 bg-rose-500 text-lg font-bold text-white px-6 py-4 rounded-md cursor-pointer") %>
+</p>
+
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+  <% @events.each do |event| %>
+    <%= link_to event_path(event), class: "block hover:shadow-lg transition duration-200" do %>
+      <div class="bg-white rounded-lg shadow p-6">
+        <h2 class="font-bold text-xl mb-2"><%= event.title %></h2>
+        <div class="text-sm text-gray-500">
+          <p>開始: <%= event.start_at.strftime("%Y年%m月%d日 %H:%M") %></p>
+          <p>会場: <%= event.venue %></p>
         </div>
-      <% end %>
+      </div>
     <% end %>
-  </div>
-
-  <%= link_to '新規イベントを作成', new_event_path, class: 'mt-8 inline-block bg-blue-600 text-white px-6 py-2 rounded hover:bg-blue-700' %>
+  <% end %>
 </div>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,4 +1,7 @@
-<div class="container mx-auto px-4 py-8">
-  <h1 class="font-bold text-4xl mb-6">新規イベント作成</h1>
-  <%= render 'form', event: @event, submit_text: '作成する' %>
-</div>
+<% content_for(:title) { "イベント登録" } %>
+
+<h2 class="text-2xl font-bold mb-4">
+  イベント登録
+</h2>
+
+<%= render("form", event: @event, submit_text: "登録する") %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -10,7 +10,7 @@
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div class="flex justify-between items-center">
         <span class="font-semibold">開始日時</span>
-        <span class="text-gray-600"><%= @event.start_at.strftime('%Y年%m月%d日 %H:%M') %></span>
+        <span class="text-gray-600"><%= mdwhm(@event.start_at) %></span>
       </div>
       <div class="flex justify-between items-center">
         <span class="font-semibold">会場</span>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,31 +1,29 @@
-<div class="container mx-auto px-4 py-8">
-  <div class="bg-white rounded-lg shadow-lg p-8">
-    <h1 class="font-bold text-4xl mb-6"><%= @event.title %></h1>
+<% content_for(:title) { @event.title } %>
 
-    <div class="mb-8">
-      <h2 class="text-xl font-semibold mb-2">イベント詳細</h2>
-      <p class="text-gray-700 mb-4"><%= @event.description %></p>
+<article class="bg-white rounded-lg shadow-lg p-6">
+  <h1 class="font-bold text-4xl mb-6"><%= @event.title %></h1>
 
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div>
-          <p class="font-semibold">開始日時:</p>
-          <p class="text-gray-600"><%= @event.start_at.strftime('%Y年%m月%d日 %H:%M') %></p>
-        </div>
-        <div>
-          <p class="font-semibold">会場:</p>
-          <p class="text-gray-600"><%= @event.venue %></p>
-        </div>
-        <div>
-          <p class="font-semibold">詳細リンク:</p>
-          <p><%= link_to '外部リンク', @event.source_link, target: '_blank', class: 'text-blue-600 hover:text-blue-800' %></p>
-        </div>
+  <div class="mb-8">
+    <h2 class="text-xl font-semibold mb-2">イベント詳細</h2>
+    <p class="text-gray-700 mb-4"><%= @event.description %></p>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div class="flex justify-between items-center">
+        <span class="font-semibold">開始日時</span>
+        <span class="text-gray-600"><%= @event.start_at.strftime('%Y年%m月%d日 %H:%M') %></span>
+      </div>
+      <div class="flex justify-between items-center">
+        <span class="font-semibold">会場</span>
+        <span class="text-gray-600"><%= @event.venue %></span>
+      </div>
+      <div class="flex justify-between items-center">
+        <span class="font-semibold">詳細リンク</span>
+        <%= link_to("リンクを開く", @event.source_link, target: "_blank", class: "text-blue-600 hover:text-blue-800") %>
       </div>
     </div>
-
-    <div class="flex space-x-4">
-      <%= link_to '編集', edit_event_path(@event), class: 'bg-green-600 text-white px-6 py-2 rounded hover:bg-green-700' %>
-      <%= link_to '削除', event_path(@event), data: { turbo_method: :delete, turbo_confirm: '本当に削除してもよろしいですか？' }, class: 'bg-red-600 text-white px-6 py-2 rounded hover:bg-red-700' %>
-      <%= link_to '戻る', events_path, class: 'bg-gray-500 text-white px-6 py-2 rounded hover:bg-gray-600' %>
-    </div>
   </div>
-</div>
+
+  <div>
+    <%= link_to("編集する", edit_event_path(@event), class: "w-full block text-center bg-rose-600 text-white px-6 py-2 rounded hover:bg-rose-400") %>
+  </div>
+</article>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -24,6 +24,10 @@
   </div>
 
   <div>
-    <%= link_to("編集する", edit_event_path(@event), class: "w-full block text-center bg-rose-600 text-white px-6 py-2 rounded hover:bg-rose-400") %>
+    <%= link_to("編集する", edit_event_path(@event), class: "w-full block text-center bg-rose-500 text-white px-6 py-2 rounded hover:bg-rose-400") %>
   </div>
 </article>
+
+<p class="text-center mt-6">
+  <%= link_to("イベント一覧に戻る", events_path) %>
+</p>


### PR DESCRIPTION
### 向き先

- https://github.com/teacherteacher-jp/manabiya/pull/102

### やること

- 余白を、他のページ群のものと揃えていく
- フォームに白地を敷くとそこにも余白を入れることになって面積を消費するので、床に直置きする
- 各ページのtitleを設定する

### コードよりスクリーンショットを見た方が意図が伝わりそう

Before

| index | new |
|--------|--------|
| ![localhost_3000_events](https://github.com/user-attachments/assets/fed1f9c9-92d8-42c5-8de7-3af514515a0d) | ![localhost_3000_events (1)](https://github.com/user-attachments/assets/9533246c-9861-45a9-b60f-bb134691222f) | 

----

After

| index | edit | show |
|--------|--------|--------|
| ![localhost_3000_events (4)](https://github.com/user-attachments/assets/dd4f426d-8684-4c06-82b1-9e963684877b) | ![localhost_3000_events_2 (1)](https://github.com/user-attachments/assets/4f0716be-e576-4192-be04-8f62a32ef7dd) | ![localhost_3000_events_2](https://github.com/user-attachments/assets/f9c863c4-cf85-4f64-900a-1294ec41a246) | 
