### PR TITLE
イベントのDiscord通知にevents#showのリンクを添える

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -32,6 +32,7 @@ class Event < ApplicationRecord
   def to_embed
     {
       title: title,
+      url: Rails.application.routes.url_helpers.event_url(self),
       fields: [
         { name: "開始日時", value: mdwhm(start_at), inline: true },
         { name: "場所", value: venue, inline: true },

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   # Set localhost to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+  # config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
@@ -66,4 +66,10 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
+
+  uri = URI.parse(Rails.application.credentials.dig("base_url"))
+  url_options = { host: uri.host, port: uri.port, protocol: uri.scheme }
+  config.action_controller.default_url_options = url_options
+  config.action_mailer.default_url_options = url_options
+  Rails.application.routes.default_url_options = url_options
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -86,4 +86,9 @@ Rails.application.configure do
   #
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+
+  url_options = { host: URI.parse(Rails.application.credentials.dig("base_url")).host, protocol: "https" }
+  config.action_controller.default_url_options = url_options
+  config.action_mailer.default_url_options = url_options
+  Rails.application.routes.default_url_options = url_options
 end


### PR DESCRIPTION
Manabiyaへのリンクがないと「わたしもイベントを登録したい！」ってときの導線が弱いかも、と思って :wave:
