### PR TITLE
イベントのフォームにおける二重Submitを防ぎたい

### DIFF
--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: event, local: true, data: { turbo: false }) do |f| %>
+<%= form_with(model: event, local: true, data: { disable_with: "保存中..." }) do |f| %>
   <div class="mb-6">
     <%= f.label(:title, "タイトル", class: "block text-gray-700 font-bold mb-2") %>
     <%= f.text_field(:title, placeholder: "イベントのタイトル (最大50文字)", class: "shadow appearance-none border #{'border-red-500' if event.errors[:title].any?} rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline") %>
@@ -41,6 +41,6 @@
 
   <div class="flex items-center justify-between">
     <%= link_to("戻る", events_path, class: "text-gray-600 hover:text-gray-800") %>
-    <%= f.submit(submit_text, class: "pointer bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline") %>
+    <%= f.submit(submit_text, class: "bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline") %>
   </div>
 <% end %>


### PR DESCRIPTION
Submitを連打すると、同じイベントがたくさん作られてしまったりする！
