### PR TITLE
discordにイベントが通知された時、Googleカレンダーリンクがエンコードされてないために壊れているのを解決する。

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -26,7 +26,8 @@ class Event < ApplicationRecord
 
   def link_to_add_to_google_calendar
     dates = "#{start_at.strftime('%Y%m%dT%H%M%S')}/#{(start_at + 1.hour).strftime('%Y%m%dT%H%M%S')}"
-    "https://calendar.google.com/calendar/render?action=TEMPLATE&text=#{title}&dates=#{dates}&location=#{venue}&ctz=Asia/Tokyo"
+    encoded_title = URI.encode_www_form_component(title)
+    "https://calendar.google.com/calendar/render?action=TEMPLATE&text=#{encoded_title}&dates=#{dates}&location=#{venue}&ctz=Asia/Tokyo"
   end
 
   def to_embed


### PR DESCRIPTION
表題通り。

## 壊れていた原因
- webアプリ上では壊れていないのに、discordの通知に記載されたGoogleカレンダーリンクは壊れていた。
- 原因は、webアプリ上では、Railsがwebアプリ上でリンクを表示する際に、URLを自動的にエンコードしてくれているので、壊れてない。しかし、discord通知では `link_to_add_to_google_calendar`メソッドの戻り値がそのまま送信されて、エンコードされてない状態でリンクが表示されるので、空白が入るとリンクが壊れてしまう。

```ruby
# text に空白が入ってしまってる
> Event.find(27).link_to_add_to_google_calendar
  Event Load (0.5ms)  SELECT "events".* FROM "events" WHERE "events"."id" = 27 LIMIT 1 /*application='Manabiya'*/
=> "https://calendar.google.com/calendar/render?action=TEMPLATE&text=勉強会 第1回&dates=20241220T120000/20241220T130000&location=談話室&ctz=Asia/Tokyo"
```


## どのように解決したか
- titleのデータをそのままURLに入れるのではなく、エンコードさせたものを入れて、リンク生成してもらうことにしました。

```ruby
# エンコードしたことにより、空白が + に変換されている
> Event.find(27).link_to_add_to_google_calendar
  Event Load (0.5ms)  SELECT "events".* FROM "events" WHERE "events"."id" = 27 LIMIT 1 /*application='Manabiya'*/
=> "https://calendar.google.com/calendar/render?action=TEMPLATE&text=勉強会+第1回&dates=20241220T120000/20241220T130000&location=談話室&ctz=Asia/Tokyo"
```