### PR TITLE
みんなのスケジュールは誰でも確認できるようにする

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -1,14 +1,14 @@
 class RootController < ApplicationController
   def index
     @menu_items = [
-      { text: "わたしのプロフィール", path: member_path(current_member) },
       { text: "わたしのスケジュール", path: my_schedules_path },
+      { text: "みんなのスケジュール", path: schedules_path },
+      { text: "わたしのプロフィール", path: member_path(current_member) },
       { text: "みんなのゆかりの地", path: regions_path },
       { text: "みんなの参加時期", path: generations_path },
     ]
 
     @admin_menu_items = [
-      { text: "みんなのスケジュール", path: schedules_path },
     ]
 
     @recent_events = Event.in_future.order(start_at: :asc).limit(3)

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -11,21 +11,6 @@
   </ul>
 </section>
 
-<% if current_member.admin? %>
-<section class="mb-6">
-  <h2 class="text-2xl font-bold mb-4">
-    管理者メニュー
-  </h2>
-  <ul>
-    <% @admin_menu_items.each do |menu_item| %>
-    <li class="mb-2">
-      <%= link_to(menu_item[:text], menu_item[:path], class: "inline-block w-full bg-white p-4 rounded-md shadow-md") %>
-    </li>
-    <% end %>
-  </ul>
-</section>
-<% end %>
-
 <section class="mb-6">
   <h2 class="text-2xl font-bold mb-4">
     イベント情報

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -45,7 +45,7 @@
       <% end %>
     </tbody>
   </table>
-  <% if index < 3 %>
+  <% if current_member.admin? && index < 3 %>
     <%= link_to("担当を決める", schedule_assignments_path(date), class: "inline-block w-full text-center font-bold mt-4 px-4 py-2 bg-sky-400 text-white rounded-md") %>
   <% end %>
 </div>


### PR DESCRIPTION
誰でも編集できちゃうと混乱するな、ってことでメニューから消したのだけれど。一覧は確認できると便利ってことだったので見えるようにします。「担当者を決める」の導線はadminだけに見せます。

