### PR TITLE
過去のイベントはそれ用のページに押し込める

### DIFF
--- a/app/controllers/events/in_past_controller.rb
+++ b/app/controllers/events/in_past_controller.rb
@@ -1,0 +1,5 @@
+class Events::InPastController < ApplicationController
+  def index
+    @events = Event.in_past.order(start_at: :desc)
+  end
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,7 +2,7 @@ class EventsController < ApplicationController
   before_action :set_event, only: [:show, :edit, :update]
 
   def index
-    @events = Event.order(start_at: :asc)
+    @events = Event.in_future.order(start_at: :asc)
   end
 
   def show

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -8,6 +8,7 @@ class Event < ApplicationRecord
   validates :source_link, presence: true
 
   scope :in_future, -> { where("start_at > ?", Time.current) }
+  scope :in_past, -> { where("start_at <= ?", Time.current) }
   after_create_commit :notify
 
   class << self

--- a/app/views/events/_nav.html.erb
+++ b/app/views/events/_nav.html.erb
@@ -1,0 +1,9 @@
+<div class="mb-4">
+  <%= link_to("これから開催", events_path, class: "text-blue-500") %>
+  |
+  <%= link_to("開催済み", events_in_past_path, class: "text-blue-500") %>
+</div>
+
+<p>
+  <%= link_to("イベントを登録する", new_event_path, class: "fixed bottom-4 right-4 bg-rose-500 text-lg font-bold text-white px-6 py-4 rounded-md cursor-pointer") %>
+</p>

--- a/app/views/events/in_past/index.html.erb
+++ b/app/views/events/in_past/index.html.erb
@@ -1,7 +1,7 @@
-<% content_for(:title) { "イベント一覧" } %>
+<% content_for(:title) { "過去のイベント一覧" } %>
 
 <h2 class="text-2xl font-bold mb-4">
-  イベント一覧
+  過去のイベント一覧
 </h2>
 
 <%= render(partial: "events/nav") %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,11 +35,12 @@ Rails.application.routes.draw do
                                                    as: "new_event"
   post   "/events",                                to: "events#create"
   get    "/events/:id",                            to: "events#show",
-                                                   as: "event"
+                                                   as: "event",
+                                                   constraints: { id: /\d+/ }
   get    "/events/:id/edit",                       to: "events#edit",
                                                    as: "edit_event"
   patch  "/events/:id",                            to: "events#update"
-
+  get    "/events/in_past",                        to: "events/in_past#index"
   get    "/public/events.ics",                     to: "public/events#index",
                                                    as: "public_events"
   post   "/webhooks/metalife",                     to: "webhooks/metalife#create"


### PR DESCRIPTION
現状の `/events` には全イベントを表示していますが、レコードが少しずつ貯まってきて、過去のイベントに埋もれて未来のイベントが見えにくくなってきました。そろそろ、過去のイベントを表示する用のページをつくって、過去イベントをそこに押し込めることで未来のイベントを見やすくします :muscle:
