### PR TITLE
Procfileに頼らずにpumaのpluginでtailwindcss:watchする

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,0 @@
-web: bin/rails server
-css: bin/rails tailwindcss:watch

--- a/bin/dev
+++ b/bin/dev
@@ -1,16 +1,2 @@
-#!/usr/bin/env sh
-
-if ! gem list foreman -i --silent; then
-  echo "Installing foreman..."
-  gem install foreman
-fi
-
-# Default to port 3000 if not specified
-export PORT="${PORT:-3000}"
-
-# Let the debug gem allow remote connections,
-# but avoid loading until `debugger` is called
-export RUBY_DEBUG_OPEN="true"
-export RUBY_DEBUG_LAZY="true"
-
-exec foreman start -f Procfile.dev "$@"
+#!/usr/bin/env ruby
+exec "./bin/rails", "server", *ARGV

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -36,6 +36,8 @@ plugin :tmp_restart
 # Run the Solid Queue supervisor inside of Puma for single-server deployments
 plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]
 
+plugin :tailwindcss if ENV.fetch("RAILS_ENV", "development") == "development"
+
 # Specify the PID file. Defaults to tmp/pids/server.pid in development.
 # In other environments, only set the PID file if requested.
 pidfile ENV["PIDFILE"] if ENV["PIDFILE"]


### PR DESCRIPTION
### 経緯

- https://github.com/teacherteacher-jp/manabiya/pull/16 でTailwindcssを導入し、そのときに `bin/dev` という便利スクリプトを導入した
- https://github.com/teacherteacher-jp/manabiya/pull/99 の通り、Rails 8になったときに `bin/dev` が配置されるようになったが、先述のTailwindcss用のやつと衝突してTailwindcss用の内容を残すことにしていた

### 今回やること

- tailwindcss-railsがPumaのpluginを用意してくれていることを知ったので、これを使うことにする
  - https://github.com/rails/tailwindcss-rails?tab=readme-ov-file#puma-plugin
- そうすると `bin/dev` とProcfileで工面する必要がなくなるので `bin/dev` はRails 8の標準のものに戻す

### これをマージすると

Development環境でのアプリケーションの起動は `./bin/rails server` でいける、あるいはこれまで通りに `./bin/dev` でも起動できます。
