### PR TITLE
StudentsとSchoolMemoについて、動かしてみて気付いたところを直していく

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -1,20 +1,23 @@
 class RootController < ApplicationController
   def index
     @school_menu_items = [
-      { text: "ボランティアのスケジュール入力", path: my_schedules_path },
-      { text: "ボランティアのスケジュール確認", path: schedules_path },
+      { text: "ボランティアのスケジュールを入力する", path: my_schedules_path },
+      { text: "ボランティアのスケジュールを確認する", path: schedules_path },
     ]
     if current_member.can_access_student_info?
       [
-        { text: "生徒さんたちの情報", path: students_path },
-        { text: "スクールに関するメモ", path: school_memos_path },
+        { text: "生徒さんたちの情報を確認する", path: students_path },
+        { text: "スクールに関するメモを書く", path: school_memos_path },
       ].each { |item| @school_menu_items << item }
+    end
+    if current_member.children_as_students.count > 0
+      @school_menu_items << { text: "家庭からのメモを書く", path: new_school_memo_path(student_ids: current_member.children_as_students.pluck(:id).map(&:to_s).join(",")) }
     end
 
     @community_menu_items = [
-      { text: "わたしのプロフィール", path: member_path(current_member) },
-      { text: "みんなのゆかりの地", path: regions_path },
-      { text: "みんなの参加時期", path: generations_path },
+      { text: "自分のプロフィールを見る", path: member_path(current_member) },
+      { text: "みんなのゆかりの地を見る", path: regions_path },
+      { text: "みんなの参加時期を見る", path: generations_path },
     ]
 
     @recent_events = Event.in_future.order(start_at: :asc).limit(3)

--- a/app/controllers/school_memos_controller.rb
+++ b/app/controllers/school_memos_controller.rb
@@ -8,7 +8,7 @@ class SchoolMemosController < ApplicationController
 
   def new
     @school_memo = SchoolMemo.new
-    @school_memo.student_ids = params[:student_ids].presence
+    @school_memo.student_ids = params[:student_ids].split(",").map(&:to_i) if params[:student_ids].present?
   end
 
   def create

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -117,11 +117,16 @@ class Notification
 
   def notify_school_stats
     thread_id = thread_id_for(:school_contact)
+    schedules = Schedule.joins(:assignment).where("schedules.date = ?", Date.today)
 
     content = [
       "実状把握のため、参加される方はManabiyaからスケジュール登録してもらえるとうれしいです :dizzy:",
       "データが実態と合っていない場合は修正してください :pray:",
-      app_base_url + "/my/schedules"
+      app_base_url + "/my/schedules",
+      "",
+      schedules.map { _1.member }.uniq.map { "<@#{_1.discord_uid}>" }.join(" "),
+      "よかったら今日の様子を下記フォームからご共有ください :relaxed:",
+      app_base_url + "/school_memos/new"
     ].join("\n")
     embeds = [school_stats_today, school_stats_30days]
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -49,8 +49,11 @@ class Notification
 
     if school_memo.students.count > 0
       students = school_memo.students.map { |student|
-        mention = "#{student.grade}の生徒さん"
-        student.parent_member.present? ? mention += "(保護者 <@!#{student.parent_member.discord_uid}>)" : mention
+        student_string = "#{student.grade}の生徒さん"
+        if student.parent_member && school_memo.category != "家庭から"
+          student_string += "(保護者 <@!#{student.parent_member.discord_uid}>)"
+        end
+        student_string
       }.join("、")
       content += "\n関連する生徒: #{students}"
     end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -16,26 +16,26 @@ class Notification
     Rails.application.credentials.dig("discord", THREAD_TYPES[type])
   end
 
+  def app_base_url
+    Rails.application.credentials.base_url
+  end
+
   def notify_student_created(student)
     thread_id = thread_id_for(:school_general)
-    content = "#{student.grade}の生徒さんが登録されました！\n%s" % [
-      Rails.application.credentials.base_url + "/students/#{student.id}"
-    ]
+    content = "#{student.grade}の生徒さんが登録されました！"
     pp @bot.send_message(channel_or_thread_id: thread_id, content:)
   end
 
   def notify_student_updated(student)
     thread_id = thread_id_for(:school_general)
-    content = "#{student.grade}の生徒さんの情報が更新されました！\n%s" % [
-      Rails.application.credentials.base_url + "/students/#{student.id}"
-    ]
+    content = "#{student.grade}の生徒さんの情報が更新されました！"
     pp @bot.send_message(channel_or_thread_id: thread_id, content:)
   end
 
   def notify_student_memo_created(student_memo)
     thread_id = thread_id_for(:school_general)
     content = "<@!#{student_memo.member.discord_uid}> さんが #{student_memo.student.grade}の生徒さんついてのメモを投稿しました！"
-    link = Rails.application.credentials.base_url + "/students/#{student_memo.student.id}"
+    link = app_base_url + "/students/#{student_memo.student.id}"
     embeds = [{
       description: [student_memo.content, link].join("\n\n"),
       author: { name: student_memo.category, icon_url: student_memo.member.icon_url },
@@ -87,7 +87,7 @@ class Notification
 
     description = "定刻になりましたら会場にお入りください！\n"
     description += ":school: [MetaLife会場](%s) | :memo: [案内ドキュメント](%s) | :calendar: [スケジュール入力](%s)" % [
-      ENV["SCHOOL_URL"], ENV["SCHOOL_DOCUMENT_URL"], Rails.application.credentials.base_url + "/my/schedules"
+      ENV["SCHOOL_URL"], ENV["SCHOOL_DOCUMENT_URL"], app_base_url + "/my/schedules"
     ]
     embeds = [{
       title: "%d/%d(%s)のボランティアの担当をお知らせ" % [date.month, date.day, %w[日 月 火 水 木 金 土][date.wday]],
@@ -107,7 +107,7 @@ class Notification
     thread_id = thread_id_for(:school_contact)
 
     content = "スケジュール入力、お待ちしています！\n"
-    content += ":calendar: [スケジュールを入力する](%s) :calendar:" % [Rails.application.credentials.base_url + "/my/schedules"]
+    content += ":calendar: [スケジュールを入力する](%s) :calendar:" % [app_base_url + "/my/schedules"]
 
     pp @bot.send_message(channel_or_thread_id: thread_id, content:)
   end
@@ -118,7 +118,7 @@ class Notification
     content = [
       "実状把握のため、参加される方はManabiyaからスケジュール登録してもらえるとうれしいです :dizzy:",
       "データが実態と合っていない場合は修正してください :pray:",
-      Rails.application.credentials.base_url
+      app_base_url + "/my/schedules"
     ].join("\n")
     embeds = [school_stats_today, school_stats_30days]
 
@@ -152,7 +152,7 @@ class Notification
     region_with_category = "「%s」(%s)" % [member_region.region.name, member_region.category]
 
     content = "<@!#{member_region.member.discord_uid}> さんが#{region_with_category}を登録しました！\n%s" % [
-      Rails.application.credentials.base_url + "/members/#{member_region.member_id}"
+      app_base_url + "/members/#{member_region.member_id}"
     ]
     pp @bot.send_message(channel_or_thread_id: thread_id, content:)
   end
@@ -162,7 +162,7 @@ class Notification
 
     content = "<@!#{family_member.member.discord_uid}> さんが「%s」を登録しました！\n%s" % [
       family_member.relationship_in_japanese,
-      Rails.application.credentials.base_url + "/members/#{family_member.member_id}"
+      app_base_url + "/members/#{family_member.member_id}"
     ]
     pp @bot.send_message(channel_or_thread_id: thread_id, content:)
   end

--- a/app/views/school_memos/_form.html.erb
+++ b/app/views/school_memos/_form.html.erb
@@ -19,7 +19,14 @@
 
   <div>
     <%= f.label(:category, "カテゴリー", class: "block text-sm font-medium text-gray-700") %>
-    <%= f.select(:category, SchoolMemo.categories.keys.map { |k| [k, k] }, {}, class: "mt-1 p-2 block w-full rounded-md bg-white border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm") %>
+    <% default_category = if current_member.admin?
+                           "コンコンから"
+                         elsif current_member.children_as_students.any? { |student| school_memo.students.include?(student) }
+                           "家庭から"
+                         else
+                           "ボランティアから"
+                         end %>
+    <%= f.select(:category, SchoolMemo.categories.keys.map { |k| [k, k] }, { selected: default_category }, class: "mt-1 p-2 block w-full rounded-md bg-white border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm") %>
   </div>
 
   <div>

--- a/app/views/students/index.html.erb
+++ b/app/views/students/index.html.erb
@@ -18,7 +18,10 @@
         <div class="bg-white overflow-hidden shadow rounded-lg">
           <div class="px-4 py-5 sm:p-6">
             <h4 class="text-lg font-medium text-gray-900 mb-2"><%= student.name %></h4>
-            <p class="text-sm text-gray-500 mb-4">学年: <%= student.grade %></p>
+            <p class="text-sm text-gray-500 mb-2"><%= student.grade %></p>
+            <% if student.parent_member %>
+              <p class="text-sm text-gray-500 mb-2">保護者: <%= student.parent_member.name %></p>
+            <% end %>
             <div class="flex justify-end">
               <%= link_to '詳細', student_path(student), class: "text-indigo-600 hover:text-indigo-900" %>
             </div>


### PR DESCRIPTION
- 保護者が「家庭から」のメモを投稿したとき、Discordでのメンションが二重にならないようにする
- Studentの一覧ページに保護者の情報も載せる
- カテゴリのデフォルト値、文脈を読み取ってもっといい感じにする
- Studentのcreate/updateのDiscord通知にはリンクを載せないでおく (アクセスできるのは一部の人なので)
- ボランティア参加してくれた人にSchoolMemoの記入を呼びかける