### PR TITLE
文字数カウンタがじゃまにならないようにtextareaのpaddingを調整する

### DIFF
--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: event, local: true, data: { disable_with: "保存中..." }) do |f| %>
+<%= form_with(model: event, local: true, data: { disable_with: "保存中...", controller: "character-counter", character_counter_max_value: 200 }) do |f| %>
   <div class="mb-6">
     <%= f.label(:title, "タイトル", class: "block text-gray-700 font-bold mb-2") %>
     <%= f.text_field(:title, placeholder: "イベントのタイトル (最大50文字)", class: "shadow-sm appearance-none border bg-white #{'border-red-500' if event.errors[:title].any?} rounded-sm w-full py-2 px-3 text-gray-700 leading-tight focus:outline-hidden focus:shadow-outline") %>
@@ -9,7 +9,18 @@
 
   <div class="mb-6">
     <%= f.label(:description, "説明", class: "block text-gray-700 font-bold mb-2") %>
-    <%= f.text_area(:description, placeholder: "イベントの概要 (最大200文字)", rows: 4, class: "shadow-sm appearance-none border bg-white #{'border-red-500' if event.errors[:description].any?} rounded-sm w-full py-2 px-3 text-gray-700 leading-tight focus:outline-hidden focus:shadow-outline") %>
+    <div class="relative">
+      <%= f.text_area(:description, placeholder: "イベントの概要 (最大200文字)", rows: 4,
+          class: "shadow-sm appearance-none border bg-white #{'border-red-500' if event.errors[:description].any?} rounded-sm w-full py-2 px-3 pb-8 text-gray-700 leading-tight focus:outline-hidden focus:shadow-outline",
+          data: {
+            character_counter_target: "input",
+            action: "input->character-counter#updateCounter"
+          }
+      ) %>
+      <div class="absolute bottom-2 right-2 text-sm text-gray-500" data-character-counter-target="counter">
+        <span>0</span>/200文字
+      </div>
+    </div>
     <% if event.errors[:description].any? %>
       <p class="text-red-500 text-xs italic mt-1"><%= event.errors[:description].join(", ") %></p>
     <% end %>
@@ -41,6 +52,9 @@
 
   <div class="flex items-center justify-between">
     <%= link_to("戻る", events_path, class: "text-gray-600 hover:text-gray-800") %>
-    <%= f.submit(submit_text, class: "bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-sm focus:outline-hidden focus:shadow-outline") %>
+    <%= f.submit(submit_text,
+        class: "bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-sm focus:outline-hidden focus:shadow-outline disabled:opacity-50 disabled:cursor-not-allowed",
+        data: { character_counter_target: "submit" }
+    ) %>
   </div>
 <% end %>

--- a/app/views/school_memos/_form.html.erb
+++ b/app/views/school_memos/_form.html.erb
@@ -39,7 +39,7 @@
     <%= f.label(:content, "メモ内容", class: "block text-sm font-medium text-gray-700") %>
     <div class="relative">
       <%= f.text_area(:content, rows: 3,
-          class: "mt-1 p-2 block w-full rounded-md bg-white border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm field-sizing-content",
+          class: "mt-1 p-2 pb-8 block w-full rounded-md bg-white border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm field-sizing-content",
           data: {
             character_counter_target: "input",
             action: "input->character-counter#updateCounter"


### PR DESCRIPTION
textareaの下paddingを大きくしたので、入力した文字と文字数カウンタは重ならなくなったはず :dash:

![padding](https://github.com/user-attachments/assets/d7cc1238-901d-4630-8f2b-6c801054021a)
