### PR TITLE
MetaLifeのWebhookで受け取ったイベント情報を保存する

### DIFF
--- a/app/controllers/webhooks/metalife_controller.rb
+++ b/app/controllers/webhooks/metalife_controller.rb
@@ -2,12 +2,12 @@ class Webhooks::MetalifeController < WebhooksController
   def create
     space_id = params[:spaceId]
 
-    case space_id
-    when Rails.application.credentials.dig(:metalife, :school_space_id)
-      metalife_user = MetalifeUser.find_or_initialize_by(metalife_id: params[:id])
-      metalife_user.update!(name: params[:name])
+    metalife_user = MetalifeUser.find_or_initialize_by(metalife_id: params[:id])
+    metalife_user.update!(name: params[:name])
 
-      handle_school_space_event(metalife_user, params)
+    save_metalife_event(metalife_user, params)
+
+    case space_id
     when Rails.application.credentials.dig(:metalife, :community_center_space_id)
       handle_community_center_event(params)
     end
@@ -17,14 +17,6 @@ class Webhooks::MetalifeController < WebhooksController
 
   private
 
-  def handle_school_space_event(metalife_user, params)
-    return unless params[:when] == "enter"
-
-    if metalife_user.linkable
-      metalife_user.notify_school_entered(params[:spaceId])
-    end
-  end
-
   def handle_community_center_event(params)
     content = params[:text]
     content += "\n<https://app.metalife.co.jp/spaces/%s>" % [params[:spaceId]] if params[:when] == "enter"
@@ -32,5 +24,18 @@ class Webhooks::MetalifeController < WebhooksController
     token = Rails.application.credentials.dig(:discord_app, :bot_token)
     thread_id = Rails.application.credentials.dig(:discord, :community_center_thread_id)
     Discord::Bot.new(token).send_message(channel_or_thread_id: thread_id, content:)
+  end
+
+  def save_metalife_event(metalife_user, params)
+    MetalifeEvent.create!(
+      metalife_user: metalife_user,
+      event_type: params[:when],
+      space_id: params[:spaceId],
+      floor_id: params[:floorId],
+      message: params[:text],
+      payload: params.to_unsafe_h
+    )
+  rescue => e
+    Rails.logger.error "Failed to save MetaLife event: #{e.message}"
   end
 end

--- a/app/models/metalife_event.rb
+++ b/app/models/metalife_event.rb
@@ -1,0 +1,27 @@
+class MetalifeEvent < ApplicationRecord
+  belongs_to :metalife_user
+
+  EVENT_TYPES = {
+    enter: 'enter',
+    leave: 'leave',
+    enter_meeting: 'enterMeeting',
+    leave_meeting: 'leaveMeeting',
+    away: 'away',
+    comeback: 'comeback',
+    interphone: 'interphone',
+    floor_move: 'floorMove',
+    chat: 'chat'
+  }.freeze
+
+  validates :event_type, presence: true, inclusion: { in: EVENT_TYPES.values }
+  validates :space_id, presence: true
+  validates :occurred_at, presence: true
+
+  before_validation :set_occurred_at
+
+  private
+
+  def set_occurred_at
+    self.occurred_at ||= Time.at(payload['timestamp'].to_i / 1000.0) if payload&.dig('timestamp')
+  end
+end

--- a/db/migrate/20250910140456_create_metalife_events.rb
+++ b/db/migrate/20250910140456_create_metalife_events.rb
@@ -1,0 +1,20 @@
+class CreateMetalifeEvents < ActiveRecord::Migration[8.0]
+  def change
+    create_table :metalife_events do |t|
+      t.references :metalife_user, foreign_key: true, index: true
+      t.string :event_type, null: false
+      t.string :space_id, null: false
+      t.string :floor_id
+      t.text :message
+      t.jsonb :payload
+      t.datetime :occurred_at, null: false
+
+      t.timestamps
+    end
+
+    add_index :metalife_events, [:metalife_user_id, :occurred_at]
+    add_index :metalife_events, [:event_type, :occurred_at]
+    add_index :metalife_events, :space_id
+    add_index :metalife_events, :occurred_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_21_140018) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_10_140456) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -64,6 +64,23 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_21_140018) do
     t.boolean "admin", default: false
     t.index ["discord_uid"], name: "index_members_on_discord_uid", unique: true
     t.index ["server_joined_at"], name: "index_members_on_server_joined_at"
+  end
+
+  create_table "metalife_events", force: :cascade do |t|
+    t.bigint "metalife_user_id"
+    t.string "event_type", null: false
+    t.string "space_id", null: false
+    t.string "floor_id"
+    t.text "message"
+    t.jsonb "payload"
+    t.datetime "occurred_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_type", "occurred_at"], name: "index_metalife_events_on_event_type_and_occurred_at"
+    t.index ["metalife_user_id", "occurred_at"], name: "index_metalife_events_on_metalife_user_id_and_occurred_at"
+    t.index ["metalife_user_id"], name: "index_metalife_events_on_metalife_user_id"
+    t.index ["occurred_at"], name: "index_metalife_events_on_occurred_at"
+    t.index ["space_id"], name: "index_metalife_events_on_space_id"
   end
 
   create_table "metalife_users", force: :cascade do |t|
@@ -251,6 +268,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_21_140018) do
   add_foreign_key "family_members", "members"
   add_foreign_key "member_regions", "members"
   add_foreign_key "member_regions", "regions"
+  add_foreign_key "metalife_events", "metalife_users"
   add_foreign_key "schedules", "members"
   add_foreign_key "school_memo_students", "school_memos"
   add_foreign_key "school_memo_students", "students"


### PR DESCRIPTION
これまでは、受け取るもののデータベースに保存はせず、一部のものだけDiscordに通知しているくらいでした。Discord通知は数が増えると煩わしくもなるので、まずはデータベースに保存して、そのあとの通知などなどを柔軟にハンドリングできるように足場を整えます :muscle:
